### PR TITLE
Fix icon 404 not found error

### DIFF
--- a/src/components/WebBrowser.tsx
+++ b/src/components/WebBrowser.tsx
@@ -34,42 +34,18 @@ export const WebBrowser = ({ initialUrl, repoName }: WebBrowserProps) => {
 
   const handleBuildApp = async () => {
     if (!repoName) return;
-    
     setBuildStatus('building');
     setIsLoading(true);
     setError(null);
-    
-    // Simulate build + probe deployed URLs
-    setTimeout(async () => {
-      const deployedUrls = [
-        `https://${repoName}.vercel.app`,
-        `https://${repoName}.netlify.app`,
-        `https://nxconner.github.io/${repoName}`,
-        `https://${repoName.toLowerCase()}.lovable.app`,
-      ];
-
-      const firstReachable = await (async () => {
-        for (const candidate of deployedUrls) {
-          try {
-            await fetch(candidate, { method: 'HEAD', mode: 'no-cors' as RequestMode });
-            // In no-cors, we can't read status; assume success if no exception
-            return candidate;
-          } catch {
-            // ignore failed candidate
-            continue;
-          }
-        }
-        return null;
-      })();
-
-      const repoUrl = `https://github.com/NXConner/${repoName}`;
-      const target = firstReachable || repoUrl;
+    // Do not probe random deployment URLs; default to GitHub or provided initialUrl
+    setTimeout(() => {
+      const target = initialUrl || `https://github.com/NXConner/${repoName}`;
       setCurrentUrl(target);
       historyRef.current = [target];
       historyIndexRef.current = 0;
       setBuildStatus('built');
       setIsLoading(false);
-    }, 1500);
+    }, 800);
   };
 
   const navigateTo = (newUrl: string, replace = false) => {


### PR DESCRIPTION
Remove in-app browser's auto-probing for Vercel/Netlify URLs to fix `DEPLOYMENT_NOT_FOUND` 404s.

The in-app browser was attempting to find deployed versions of repositories on platforms like Vercel and Netlify by constructing URLs and checking for their existence. This often led to navigating to non-existent deployments, resulting in Vercel's `DEPLOYMENT_NOT_FOUND` error. This change ensures the browser defaults to the GitHub repository page or a provided initial URL, avoiding these phantom deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-2fe9384d-11a9-4151-b719-9c83b5f7aa39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2fe9384d-11a9-4151-b719-9c83b5f7aa39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

